### PR TITLE
Childless img fix

### DIFF
--- a/src/Internal.elm
+++ b/src/Internal.elm
@@ -134,6 +134,7 @@ toStringHelper tags acc =
                     children
                     { acc
                         | result = tag "img" (Attribute "src" (cid src) :: attributes) :: acc.result
+                        , inlineImages = inlineImages
                     }
 
             else

--- a/tests/SendGrid/Internal.elm
+++ b/tests/SendGrid/Internal.elm
@@ -1,5 +1,6 @@
 module SendGrid.Internal exposing (..)
 
+import Bytes.Encode
 import Email.Html
 import Email.Html.Attributes
 import Expect exposing (Expectation)
@@ -40,5 +41,15 @@ suite =
                         |> Internal.toString
                         |> Tuple.first
                         |> Expect.equal "<div>line 1<br>inside br</br>line 2</div>"
+            , test "Handle <img> without children" <|
+                \_ ->
+                    let
+                        emptyImageContent =
+                            (Bytes.Encode.encode <| Bytes.Encode.string "")
+                    in
+                    Email.Html.inlinePngImg emptyImageContent [] []
+                        |> Internal.toString
+                        |> Tuple.second
+                        |> Expect.equalLists [("inline-image0.png",{ content = emptyImageContent, imageType = Internal.Png })]
             ]
         ]


### PR DESCRIPTION
Noticed that Internal.toString wouldn't return the attachments for inline images if the image node has no children.